### PR TITLE
Respond with the saved image

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -40,7 +40,10 @@ async def save_image(interaction: discord.Interaction, attachment: discord.Attac
 
         # save the image
         await attachment.save(f"images/{id}.jpg")
-        await interaction.response.send_message("Image Saved.")
+        
+        # respond to the command with the image that was saved
+        file = discord.File(f"images/{id}.jpg")
+        await interaction.response.send_message(content="Image Saved.", file=file)
     else:
         await interaction.response.send_message(
             "File size too big. Please ensure it is under 8MB.", ephemeral=True


### PR DESCRIPTION
The `/save` command can now respond with the image saved.

![244459831-9cdcce8e-ebdf-4a3b-ac69-fd8a2b932d2e](https://github.com/HeelMePlz/high-heels-discord-bot/assets/78705543/d7e2f6b0-bea5-4061-9793-67e0eda9391c)

Closes #1 